### PR TITLE
Fixes #537: finally block needs a null check on writer, writer will be null if initializations fails

### DIFF
--- a/java/extentreports/src/main/java/com/relevantcodes/extentreports/ExtentReports.java
+++ b/java/extentreports/src/main/java/com/relevantcodes/extentreports/ExtentReports.java
@@ -785,14 +785,8 @@ public class ExtentReports extends Report implements Serializable {
      *      An {@link ExtentTest} object
      */
     public synchronized ExtentTest startTest(String testName, String description) {
-        if (testList == null) {
-            testList = new ArrayList<ExtentTest>();
-        }
-        
-        ExtentTest test = new ExtentTest(testName, description);
-        
+        ExtentTest test = new ExtentTest(testName, description);        
         updateTestQueue(test);
-        
         return test;
     }
     

--- a/java/extentreports/src/main/java/com/relevantcodes/extentreports/Report.java
+++ b/java/extentreports/src/main/java/com/relevantcodes/extentreports/Report.java
@@ -228,7 +228,7 @@ abstract class Report extends LogSettings {
     
     protected SuiteTimeInfo suiteTimeInfo;
     protected SystemInfo systemInfo;
-    protected List<ExtentTest> testList;
+    protected List<ExtentTest> testList = new ArrayList<ExtentTest>();
     protected File configFile = null;
     
     protected List<ExtentTest> getTestList() {

--- a/java/extentreports/src/main/java/com/relevantcodes/extentreports/utils/Writer.java
+++ b/java/extentreports/src/main/java/com/relevantcodes/extentreports/utils/Writer.java
@@ -25,7 +25,8 @@ public class Writer {
         } 
         finally {
             try {
-              writer.close();
+            	if(writer != null)
+            		writer.close();
             } 
             catch (Exception e) {
             	e.printStackTrace();


### PR DESCRIPTION
If writer initialisation fails because of some reason, then finally block will try to close the writer and will get a null pointer.
