### PR TITLE
Fixed the width for the first 2 columns specific to particular table instead of applying to all table

### DIFF
--- a/dist/css/extent.css
+++ b/dist/css/extent.css
@@ -395,10 +395,10 @@ nav ul i {
     .test-steps, .category-tests, .exception-tests, .test-content > .node-list {
         margin-top: 30px;
     }
-    .test-steps th:first-child, tr.log > td:first-child, .node-steps th:first-child, .node-steps td:first-child {
+    .test-steps th:first-child, tr.log > td:first-child, .node-steps > .table-results > thead > tr > th:first-child, .node-steps > .table-results > tbody > tr > td:first-child {
         width: 60px;
     }
-    .test-steps th:nth-child(2), tr.log > td:nth-child(2), .node-steps th:nth-child(2), .node-steps td:nth-child(2) {
+    .test-steps th:nth-child(2), tr.log > td:nth-child(2), .node-steps > .table-results > thead > tr > th:nth-child(2), .node-steps > .table-results > tbody > tr > td:nth-child(2) {
         width: 110px;
     }
     .bdd + #step-filters {


### PR DESCRIPTION
Currently the 60 px for the 1st column and 110 px for the 2nd column for all tables under the step view is being applied. Due to this when we use `test.info(MarkupHelper.createTable(data))`, the same width size is being applied, that makes the markup table created by user looks not elegant.

So added a constraint to apply the 60px and 110px only to the `table-results` table, not for everything.