### PR TITLE
Fixed the exception view where it was showing only the last exception

### DIFF
--- a/dist/css/extent.css
+++ b/dist/css/extent.css
@@ -560,6 +560,10 @@ nav ul i {
     color: #22a1c4;
 }
 
+ul#exception-collection > li.exception {
+    cursor: pointer;
+}
+
 /* -- [ theme, dark ] -- */
 body.dark, .dark .collapsible-header {
     background: #111 !important;

--- a/src/main/java/com/aventstack/extentreports/ExceptionTestContextImpl.java
+++ b/src/main/java/com/aventstack/extentreports/ExceptionTestContextImpl.java
@@ -16,13 +16,11 @@ public class ExceptionTestContextImpl {
     }   
     
     public void setExceptionContext(ExceptionInfo ei, Test test) {
-        reset();
-        
         Optional<ExceptionTestContext> exOptionalTestContext = exTestContextList
                 .stream()
                 .filter(x -> x.getExceptionInfo().getExceptionName().equals(ei.getExceptionName()))
                 .findFirst();
-        
+
         if (exOptionalTestContext.isPresent()) {
             exOptionalTestContext.get().setTest(test);
         }
@@ -33,12 +31,8 @@ public class ExceptionTestContextImpl {
             exTestContextList.add(exTestContext);
         }
     }
-    
-    private void reset() {
-        exTestContextList.clear();
-    }
 
-    public List<ExceptionTestContext> getExceptionTestContextList() { 
-        return exTestContextList; 
+    public List<ExceptionTestContext> getExceptionTestContextList() {
+        return exTestContextList;
     }
 }

--- a/src/main/java/com/aventstack/extentreports/ExtentTest.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentTest.java
@@ -400,8 +400,6 @@ public class ExtentTest implements IAddsMedia<ExtentTest>, RunResult, Serializab
         exInfo.setStackTrace(ExceptionUtil.getStackTrace(t));
         
         getModel().setExceptionInfo(exInfo);
-        if (getModel().getLevel() > 1)
-            getModel().getParent().setExceptionInfo(exInfo);
         
         log(status, exInfo.getStackTrace(), provider);
         

--- a/src/main/java/com/aventstack/extentreports/Report.java
+++ b/src/main/java/com/aventstack/extentreports/Report.java
@@ -100,8 +100,6 @@ abstract class Report implements IReport {
     }
     
     synchronized void addLog(Test test, Log log) {
-        collectRunInfo();
-        
         reporterCollection.forEach(x -> x.onLogAdded(test, log));
     }
     

--- a/src/main/resources/com/aventstack/extentreports/view/html-report/exception-view/exception-view.ftl
+++ b/src/main/resources/com/aventstack/extentreports/view/html-report/exception-view/exception-view.ftl
@@ -42,11 +42,15 @@
 								</thead>
 								<tbody>
 									<#list exception.getTestList() as test>
-									<tr>
-										<td>${ test.startTime?datetime?string["${timeStampFormat}"] }</td>
-										<td class='linked' test-id='${ test.getID() }'>${ test.hierarchicalName }</td>
-										<td><pre>${ exception.exceptionInfo.getStackTrace() }</pre></td>
-									</tr>
+										<#list test.getExceptionInfoList() as testException>
+											<#if testException.getExceptionName() == exception.exceptionInfo.getExceptionName()>
+												<tr>
+													<td>${ test.startTime?datetime?string["${timeStampFormat}"] }</td>
+													<td class='linked' test-id='${ test.getID() }'>${ test.hierarchicalName }</td>
+													<td><pre>${ testException.getStackTrace() }</pre></td>
+												</tr>
+											</#if>
+										</#list>
 									</#list>
 								</tbody>
 							</table>


### PR DESCRIPTION
The following are the changes as part of this PR:

- Fixes issue #808  
- Now it lists down all the exceptions. Also, we were leveraging the child exception to all the parents which seems to be not required. I had removed and keeps the exception only the node which throws that
- Refactored the exception view template to show all the stacktraces
- Also updated the css to show the cursor as pointer when hovering on the exception list item instead of text cursor