### PR TITLE
Enabled MarkupHelper for extending

### DIFF
--- a/src/main/java/com/aventstack/extentreports/markuputils/MarkupHelper.java
+++ b/src/main/java/com/aventstack/extentreports/markuputils/MarkupHelper.java
@@ -2,8 +2,6 @@ package com.aventstack.extentreports.markuputils;
 
 public class MarkupHelper {
     
-    private MarkupHelper() { }
-    
     public static Markup createLabel(String text, ExtentColor color) {
         Label l = new Label();
         l.setText(text);


### PR DESCRIPTION
This change helps user to add their own markup utils and perform further customisation. Earlier the class were having private constructor, due to this user will not be able to extend and add their own markup utils.