### PR TITLE
Fixed displaying the image title in the featherlight window if the title is set for the screenshot capture

### DIFF
--- a/dist/js/extent.js
+++ b/dist/js/extent.js
@@ -61,7 +61,12 @@ $(document).ready(function() {
 
     $('#test-collection .test').dynamicTestSearch('#test-view #search-tests');
 	$('#category-collection .category').dynamicTestSearch('#category-view #search-tests');
-	$('#exception-collection .exception').dynamicTestSearch('#exception-view #search-tests');  
+	$('#exception-collection .exception').dynamicTestSearch('#exception-view #search-tests');
+
+    $.featherlight.prototype.beforeContent = function () {
+        var title = this.content;
+        if (title) (this.$instance.find('.featherlight-content > span')).after($("<h5 class='center-align'>" + title + "</h5>"));
+    };
 });
 
 /* -- [ sidenav - toggle views ] -- */

--- a/src/main/java/com/aventstack/extentreports/model/ScreenCapture.java
+++ b/src/main/java/com/aventstack/extentreports/model/ScreenCapture.java
@@ -5,11 +5,11 @@ public class ScreenCapture extends Media {
     private static final long serialVersionUID = -3413285738443448335L;
 
     public String getSource() {
-        return "<img data-featherlight='" + getPath() + "' width='10%' src='' data-src='" + getPath() + "'>";
+        return "<img data-featherlight='" + getPath() + "' data-featherlight-content='" + getName() + "' width='10%' src='' data-src='" + getPath() + "'>";
     }
     
     public String getSourceWithIcon() {
-        return "<a href='#' data-featherlight='" + getPath() + "'><i class='material-icons'>photo</i></a>";
+        return "<a href='#' data-featherlight='" + getPath() + "' data-featherlight-content='" + getName() + "'><i class='material-icons'>photo</i></a>";
     }
 
 }

--- a/src/main/resources/com/aventstack/extentreports/view/html-report/head.ftl
+++ b/src/main/resources/com/aventstack/extentreports/view/html-report/head.ftl
@@ -14,7 +14,7 @@
 	<#if cdn == 'extentreports'>
 		<link href='http://extentreports.com/resx/dist/css/extent.css' type='text/css' rel='stylesheet' />
 	<#else>
-		<link href='${ config.getValue('protocol') }://cdn.rawgit.com/anshooarora/extentreports-java/0ef94479b1fc7c18041d6bbf1a8cfbfa321edc0a/dist/css/extent.css' type='text/css' rel='stylesheet' />
+		<link href='${ config.getValue('protocol') }://cdn.rawgit.com/anshooarora/extentreports-java/c458e8a7/dist/css/extent.css' type='text/css' rel='stylesheet' />
 	</#if>
 	
 	<title>${ config.getValue('documentTitle') }</title>

--- a/src/main/resources/com/aventstack/extentreports/view/html-report/index.ftl
+++ b/src/main/resources/com/aventstack/extentreports/view/html-report/index.ftl
@@ -94,7 +94,7 @@
 		<#if cdn == 'extentreports'>
 			<script src='http://extentreports.com/resx/dist/js/extent.js' type='text/javascript'></script>
 		<#else>
-			<script src='${ config.getValue('protocol') }://cdn.rawgit.com/anshooarora/extentreports-java/29d2d3ec024c953e6341cb3e19e31b1035a8f556/dist/js/extent.js' type='text/javascript'></script>
+			<script src='${ config.getValue('protocol') }://cdn.rawgit.com/anshooarora/extentreports-java/c458e8a7/dist/js/extent.js' type='text/javascript'></script>
 		</#if>
 		
 		<#assign hideChart=(chartVisibleOnOpen=='true')?then(false, true)>

--- a/src/main/resources/com/aventstack/extentreports/view/html-report/test-view/bdd.ftl
+++ b/src/main/resources/com/aventstack/extentreports/view/html-report/test-view/bdd.ftl
@@ -14,7 +14,7 @@
 		<#if node.screenCaptureList?? && node.screenCaptureList?size != 0>
 		<ul class='screenshots right'>
 			<#list node.screenCaptureList as sc>
-			<li><a data-featherlight="image" href="${ sc.path }"><i class='material-icons'>panorama</i></a></li>
+			<li><a data-featherlight="image" data-featherlight-content="${sc.name!''}" href="${ sc.path }"><i class='material-icons'>panorama</i></a></li>
 			</#list>
 		</ul>
 		</#if>
@@ -30,7 +30,7 @@
 			<#if child.screenCaptureList?? && child.screenCaptureList?size != 0>
 			<ul class='screenshots right'>
 				<#list child.screenCaptureList as sc>
-				<li><a data-featherlight="image" href="${ sc.path }"><i class='material-icons'>panorama</i></a></li>
+				<li><a data-featherlight="image" data-featherlight-content="${sc.name!''}" href="${ sc.path }"><i class='material-icons'>panorama</i></a></li>
 				</#list>
 			</ul>
 			</#if>


### PR DESCRIPTION
To reproduce the issue:

```java
public static void main(String[] args) throws IOException {
        bddRun();
    }

    private static void bddRun() throws IOException {
        // start reporters
        ExtentHtmlReporter htmlReporter = new ExtentHtmlReporter("extent.html");

        // create ExtentReports and attach reporter(s)
        ExtentReports extent = new ExtentReports();
        extent.attachReporter(htmlReporter);

        ExtentTest feature1 = extent.createTest("Feature 1");
        ExtentTest scenario1 = feature1.createNode(Scenario.class, "Scenario 1");
        scenario1.createNode(When.class, "Step 2")
                .fail(new IllegalStateException("Second test failed"))
                .addScreenCaptureFromPath("/Users/vimalrajselvam/Desktop/issue_1.png", "My screenshot");
        extent.flush();
    }
```

The 2nd parameter on the `addScreenCaptureFromPath` was not used anywhere. Now this PR addresses that issue by adding the 2nd parameter value as the title in the opened featherlight image box.