### PR TITLE
Fixed issue #926

### DIFF
--- a/src/main/java/com/aventstack/extentreports/Report.java
+++ b/src/main/java/com/aventstack/extentreports/Report.java
@@ -208,7 +208,7 @@ abstract class Report implements IReport {
                     reportStartDate = testStartDate;
                 }
 
-                if (reportEndDate.getTime() > testEndTime) {
+                if (reportEndDate.getTime() < testEndTime) {
                     reportEndDate = testEndDate;
                 }
             });


### PR DESCRIPTION
Dashboard End time-stamp is not set correctly (takes the end date of the first test).
https://github.com/anshooarora/extentreports-java/issues/926

@anshooarora , please merge and let's commit to maven as this issue has a high impact on all reports that use this mechanism.